### PR TITLE
feat: inject git rev at build time and expose as zome call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,6 +3462,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "version_coordinator"
+version = "0.0.1"
+dependencies = [
+ "hdk",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/version_coordinator/Cargo.toml
+++ b/crates/version_coordinator/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "version_coordinator"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "version_coordinator"
+
+[dependencies]
+hdk = { workspace = true }

--- a/crates/version_coordinator/build.rs
+++ b/crates/version_coordinator/build.rs
@@ -1,0 +1,9 @@
+use std::process::Command;
+fn main() {
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .expect("Can get git revision");
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/crates/version_coordinator/src/lib.rs
+++ b/crates/version_coordinator/src/lib.rs
@@ -1,0 +1,7 @@
+use hdk::prelude::*;
+
+/// Returns the monorepo git commit revision that was injected at build time.
+#[hdk_extern]
+pub fn git_rev(_: ()) -> ExternResult<String> {
+    Ok(env!("GIT_HASH").to_string())
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build:dna": "scripts/build_dna.sh",
-    "test:tryorama": "npm run build:dna && npm run -w @holoom/types build && npm run -w @holoom/client -w @holoom/authority build && npm t -w @holoom/tryorama",
+    "test:tryorama": "npm run build:dna && npm run prepare-build:types && npm run -w @holoom/client -w @holoom/authority build && npm t -w @holoom/tryorama",
     "test:dna": "npm run build:dna && cargo nextest run -j 1",
     "prepare-build:types": "rimraf crates/holoom_types/bindings && cargo test --package holoom_types && npm run -w @holoom/types prepare:bindings && npm run -w @holoom/types build",
     "build:client": "npm run build -w @holoom/client",

--- a/packages/tryorama/src/signer/sign.test.ts
+++ b/packages/tryorama/src/signer/sign.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "vitest";
 import { runScenario } from "@holochain/tryorama";
 
 import { setupAliceOnly } from "../utils/setup-happ.js";
-import { bindCoordinators } from "../utils/bindings.js";
 import { sha512 } from "@noble/hashes/sha512";
 import * as ed from "@noble/ed25519";
 import { encode } from "@msgpack/msgpack";

--- a/packages/tryorama/src/utils/bindings.ts
+++ b/packages/tryorama/src/utils/bindings.ts
@@ -1,11 +1,16 @@
 import { AppClient } from "@holochain/client";
 import { Player } from "@holochain/tryorama";
-import { UsernameRegistryCoordinator, SignerCoordinator } from "@holoom/types";
+import {
+  UsernameRegistryCoordinator,
+  SignerCoordinator,
+  VersionCoordinator,
+} from "@holoom/types";
 
 export function bindCoordinators(player: Player) {
   const appClient = player.appWs as AppClient;
   return {
     signer: new SignerCoordinator(appClient),
     usernameRegistry: new UsernameRegistryCoordinator(appClient),
+    version: new VersionCoordinator(appClient),
   };
 }

--- a/packages/tryorama/src/version/git-rev.test.ts
+++ b/packages/tryorama/src/version/git-rev.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "vitest";
+import { runScenario } from "@holochain/tryorama";
+import { execSync } from "node:child_process";
+
+import { setupAliceOnly } from "../utils/setup-happ.js";
+
+test("Injected git revision matches monorepo's", async () => {
+  await runScenario(async (scenario) => {
+    const { aliceCoordinators } = await setupAliceOnly(scenario);
+
+    const revision = await execSync("git rev-parse HEAD").toString().trim();
+    expect(/^[a-f0-9]{40}/.test(revision)).toBe(true);
+
+    await expect(aliceCoordinators.version.gitRev()).resolves.toBe(revision);
+  });
+});

--- a/packages/types/src/zome-functions/VersionCoordinator.ts
+++ b/packages/types/src/zome-functions/VersionCoordinator.ts
@@ -1,0 +1,18 @@
+import { AppClient } from "@holochain/client";
+
+export class VersionCoordinator {
+  constructor(
+    private readonly client: AppClient,
+    private readonly roleName = "holoom",
+    private readonly zomeName = "version",
+  ) {}
+
+  async gitRev(): Promise<string> {
+    return this.client.callZome({
+      role_name: this.roleName,
+      zome_name: this.zomeName,
+      fn_name: "git_rev",
+      payload: null,
+    });
+  }
+}

--- a/packages/types/src/zome-functions/index.ts
+++ b/packages/types/src/zome-functions/index.ts
@@ -2,3 +2,4 @@ export * from "./PingCoordinator";
 export * from "./RecordsCoordinator";
 export * from "./SignerCoordinator";
 export * from "./UsernameRegistryCoordinator";
+export * from "./VersionCoordinator";

--- a/workdir/dna.yaml
+++ b/workdir/dna.yaml
@@ -27,3 +27,6 @@ coordinator:
     - name: ping
       hash: ~
       bundled: "../target/wasm32-unknown-unknown/release/ping_coordinator.wasm"
+    - name: version
+      hash: ~
+      bundled: "../target/wasm32-unknown-unknown/release/version_coordinator.wasm"


### PR DESCRIPTION
Expose build-time git revision as a zome function in the interests of enabling https://github.com/holochain-open-dev/holoom/issues/100